### PR TITLE
infra: add pr template in .github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+---
+name: Pull request 2
+about: Create a pull request to merge changes
+title: 'feat: Add wobble on incorrect (keep short, use imperative mood)'
+labels: ''
+assignees: ''
+projects: Development and operations
+---
+
+<!--
+title: 'docs: Contrast web and native'
+          └── feat, fix, content, docs, style, refactor, test or infra
+-->
+
+- [ ] I did all of the following:
+  <!-- Check the box by putting an X between the brackets: [X] -->
+  - read the [contributing guidelines](
+      https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
+  - read and commit to follow the [Code of Conduct](
+      https://github.com/nodepa/seedling/blob/main/CODE_OF_CONDUCT.md)
+
+## Why is this change necessary?
+
+## How is the need addressed?
+
+## What issues are covered?
+
+<!-- Close #123, #234 -->


### PR DESCRIPTION
Because adding it under .github/PULL_REQUEST_TEMPLATE
seems to require setting the `template` param:
- add template under .github