### PR TITLE
infra: Add git commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,28 @@
+feat: Add feature <use present tense imperative mood>
+# └── feat, fix, content, docs, style, refactor, test or infra─────────┤
+
+# Motivation - Why is this change necessary?
+Because
+
+# Impact - What will this change do?
+- add
+
+# Closes/fixes #<issue number>, #<issue number>
+Closes #999991, #999992
+
+
+# ─────────────────────────────────────────────────────────────wrap<=72┘
+
+
+# Examples
+# ─────────────────────────────────────────────────────────────────────┐
+# refactor: Rename varB to audioElement
+#
+# Because the original name is uninformative
+# and make it unnecessarily hard to follow the logic:
+#
+# - improve code readability
+#   - rename varB to audioElement in InstructionsDirective.ts
+#
+# Closes #123
+# ─────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Because I am still wondering what happens with the commit message
when creating a pull request using a pull request template:
- create a file as an excuse to commit and create a pull request

- [ ] I did all of the following:
  <!-- Check the box by putting an X between the brackets: [X] -->
  - read the [contributing guidelines](
      https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
  - read and commit to follow the [Code of Conduct](
      https://github.com/nodepa/seedling/blob/main/CODE_OF_CONDUCT.md)

## Why is this change necessary?

## How is the need addressed?

## What issues are covered?

<!-- Close #123, #234 -->
